### PR TITLE
Relax dependency of base

### DIFF
--- a/simple-sql-parser.cabal
+++ b/simple-sql-parser.cabal
@@ -39,7 +39,7 @@ library
                        Language.SQL.SimpleSQL.Combinators,
                        Language.SQL.SimpleSQL.Dialect
   other-extensions:    TupleSections
-  build-depends:       base >=4.5 && <4.9,
+  build-depends:       base ,
                        parsec >=3.1 && <3.2,
                        mtl >=2.1 && <2.3,
                        pretty >= 1.1 && < 1.2
@@ -52,7 +52,7 @@ Test-Suite Tests
   type:                exitcode-stdio-1.0
   main-is:             RunTests.lhs
   hs-source-dirs:      .,tools
-  Build-Depends:       base >=4.5 && <4.9,
+  Build-Depends:       base ,
                        parsec >=3.1 && <3.2,
                        mtl >=2.1 && <2.3,
                        pretty >= 1.1 && < 1.2,
@@ -93,7 +93,7 @@ Test-Suite Tests
 executable SimpleSqlParserTool
   main-is:             SimpleSqlParserTool.lhs
   hs-source-dirs:      .,tools
-  Build-Depends:       base >=4.5 && <4.9,
+  Build-Depends:       base ,
                        parsec >=3.1 && <3.2,
                        mtl >=2.1 && <2.3,
                        pretty >= 1.1 && < 1.2,
@@ -109,7 +109,7 @@ executable SimpleSqlParserTool
 executable Fixity
   main-is:             Fixity.lhs
   hs-source-dirs:      .,tools
-  Build-Depends:       base >=4.5 && <4.9,
+  Build-Depends:       base ,
                        parsec >=3.1 && <3.2,
                        mtl >=2.1 && <2.3,
                        pretty >= 1.1 && < 1.2,


### PR DESCRIPTION
Hi Jack, 

GHC 8 requires base 4.9 . Most users will nowadays use stack to install their packages. Stack will ensure the right version of base for the version of GHC that is used. This patch relaxes the requirment. 