### PR TITLE
Parse constraints not separated by comma

### DIFF
--- a/Language/SQL/SimpleSQL/Dialect.lhs
+++ b/Language/SQL/SimpleSQL/Dialect.lhs
@@ -90,6 +90,8 @@ Data types to represent different dialect options
 >     ,diSqlServerSymbols :: Bool
 >      -- | allow sql server style for CONVERT function in format CONVERT(data_type(length), expression, style)
 >     ,diConvertFunction :: Bool
+>      -- | allow creating autoincrement columns
+>     ,diAutoincrement :: Bool
 >     }
 >                deriving (Eq,Show,Read,Data,Typeable)
 
@@ -112,6 +114,7 @@ Data types to represent different dialect options
 >                    ,diPostgresSymbols = False
 >                    ,diSqlServerSymbols = False
 >                    ,diConvertFunction = False                     
+>                    ,diAutoincrement = False
 >                    }
 
 > -- | mysql dialect

--- a/Language/SQL/SimpleSQL/Parse.lhs
+++ b/Language/SQL/SimpleSQL/Parse.lhs
@@ -1509,12 +1509,17 @@ TODO: change style
 >     CreateSchema <$> names
 
 > createTable :: Parser Statement
-> createTable = keyword_ "table" >>
+> createTable = do 
+>   let 
+>     parseColumnDef = TableColumnDef <$> columnDef 
+>     parseConstraintDef = uncurry TableConstraintDef <$> tableConstraintDef
+>     constraints = sepBy parseConstraintDef (optional comma)
+>     entries = ((:) <$> parseColumnDef <*> ((comma >> entries) <|> pure [])) <|> constraints
+>
+>   keyword_ "table" >>
 >     CreateTable
->     <$> names
->     -- todo: is this order mandatory or is it a perm?
->     <*> parens (commaSep1 (uncurry TableConstraintDef <$> tableConstraintDef
->                            <|> TableColumnDef <$> columnDef))
+>     <$> names 
+>     <*> parens entries
 
 > createIndex :: Parser Statement
 > createIndex =

--- a/Language/SQL/SimpleSQL/Parse.lhs
+++ b/Language/SQL/SimpleSQL/Parse.lhs
@@ -1600,7 +1600,10 @@ TODO: change style
 >     unique = ColUniqueConstraint <$ keyword_ "unique"
 >     primaryKey = do
 >       keywords_ ["primary", "key"] 
->       autoincrement <- optionMaybe (keyword_ "autoincrement")
+>       d <- getState
+>       autoincrement <- if diAutoincrement d 
+>         then optionMaybe (keyword_ "autoincrement")
+>         else pure Nothing
 >       pure $ ColPrimaryKeyConstraint $ isJust autoincrement
 >     check = keyword_ "check" >> ColCheckConstraint <$> parens scalarExpr
 >     references = keyword_ "references" >>

--- a/Language/SQL/SimpleSQL/Parse.lhs
+++ b/Language/SQL/SimpleSQL/Parse.lhs
@@ -1592,13 +1592,16 @@ TODO: change style
 > colConstraintDef :: Parser ColConstraintDef
 > colConstraintDef =
 >     ColConstraintDef
->     <$> (optionMaybe (keyword_ "constraint" *> names))
+>     <$> optionMaybe (keyword_ "constraint" *> names)
 >     <*> (nullable <|> notNull <|> unique <|> primaryKey <|> check <|> references)
 >   where
 >     nullable = ColNullableConstraint <$ keyword "null"
 >     notNull = ColNotNullConstraint <$ keywords_ ["not", "null"]
 >     unique = ColUniqueConstraint <$ keyword_ "unique"
->     primaryKey = ColPrimaryKeyConstraint <$ keywords_ ["primary", "key"]
+>     primaryKey = do
+>       keywords_ ["primary", "key"] 
+>       autoincrement <- optionMaybe (keyword_ "autoincrement")
+>       pure $ ColPrimaryKeyConstraint $ isJust autoincrement
 >     check = keyword_ "check" >> ColCheckConstraint <$> parens scalarExpr
 >     references = keyword_ "references" >>
 >         (\t c m (ou,od) -> ColReferencesConstraint t c m ou od)

--- a/Language/SQL/SimpleSQL/Pretty.lhs
+++ b/Language/SQL/SimpleSQL/Pretty.lhs
@@ -702,7 +702,8 @@ Try to do this when this code is ported to a modern pretty printing lib.
 >         <+> pcon con
 >     pcon ColNotNullConstraint = texts ["not","null"]
 >     pcon ColUniqueConstraint = text "unique"
->     pcon ColPrimaryKeyConstraint = texts ["primary","key"]
+>     pcon (ColPrimaryKeyConstraint autoincrement) = 
+>       texts $ ["primary","key"] ++ ["autoincrement"|autoincrement]
 >     pcon (ColCheckConstraint v) = text "check" <+> parens (scalarExpr d v)
 >     pcon (ColReferencesConstraint tb c m u del) =
 >         text "references"

--- a/Language/SQL/SimpleSQL/Syntax.lhs
+++ b/Language/SQL/SimpleSQL/Syntax.lhs
@@ -44,6 +44,7 @@
 >     ,IdentityWhen(..)
 >     ,SequenceGeneratorOption(..)
 >     ,ColConstraintDef(..)
+>     ,AutoincrementClause
 >     ,ColConstraint(..)
 >     ,TableConstraint(..)
 >     ,ReferenceMatch(..)
@@ -575,11 +576,13 @@ I'm not sure if this is valid syntax or not.
 >       -- (Maybe [ConstraintCharacteristics])
 >     deriving (Eq,Show,Read,Data,Typeable)
 
+> type AutoincrementClause = Bool
+>
 > data ColConstraint =
 >     ColNullableConstraint
 >   | ColNotNullConstraint
 >   | ColUniqueConstraint
->   | ColPrimaryKeyConstraint
+>   | ColPrimaryKeyConstraint AutoincrementClause
 >   | ColReferencesConstraint [Name] (Maybe Name)
 >        ReferenceMatch
 >        ReferentialAction
@@ -730,6 +733,6 @@ I'm not sure if this is valid syntax or not.
 
 > -- | Comment. Useful when generating SQL code programmatically. The
 > -- parser doesn't produce these.
-> data Comment = BlockComment String
+> newtype Comment = BlockComment String
 >                deriving (Eq,Show,Read,Data,Typeable)
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-with import <nixpkgs> {};
+with import <nixpkgs> { };
 stdenv.mkDerivation rec {
   name = "env";
   env = buildEnv { name = name; paths = buildInputs; };
@@ -6,6 +6,7 @@ stdenv.mkDerivation rec {
     ghc
     cabal-install
     glibcLocales
+    gnumake
   ];
   shellHook = "export LANG=en_GB.UTF-8";
 }

--- a/tools/Language/SQL/SimpleSQL/SQL2011Schema.lhs
+++ b/tools/Language/SQL/SimpleSQL/SQL2011Schema.lhs
@@ -332,7 +332,13 @@ todo: constraint characteristics
 >       "create table t (a int primary key);"
 >      $ CreateTable [Name Nothing "t"]
 >        [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
->         [ColConstraintDef Nothing ColPrimaryKeyConstraint]])
+>         [ColConstraintDef Nothing (ColPrimaryKeyConstraint False)]])
+
+>     ,(TestStatement ansi2011
+>       "create table t (a int primary key autoincrement);"
+>      $ CreateTable [Name Nothing "t"]
+>        [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+>         [ColConstraintDef Nothing (ColPrimaryKeyConstraint True)]])
 
 references t(a,b)
   [ Full |partial| simepl]

--- a/tools/Language/SQL/SimpleSQL/SQL2011Schema.lhs
+++ b/tools/Language/SQL/SimpleSQL/SQL2011Schema.lhs
@@ -645,6 +645,28 @@ defintely skip
 >                 DefaultReferentialAction DefaultReferentialAction
 >        ])
 
+>     ,(TestStatement ansi2011
+>       "create table t (a int, b int,\n\
+>       \                foreign key (a) references u(c)\n\
+>       \                foreign key (b) references v(d));"
+>      $ CreateTable [Name Nothing "t"]
+>        [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
+>        ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+>        ,TableConstraintDef Nothing $
+>             TableReferencesConstraint
+>                 [Name Nothing "a"]
+>                 [Name Nothing "u"]
+>                 (Just [Name Nothing "c"])
+>                 DefaultReferenceMatch
+>                 DefaultReferentialAction DefaultReferentialAction
+>        ,TableConstraintDef Nothing $
+>             TableReferencesConstraint
+>                 [Name Nothing "b"]
+>                 [Name Nothing "v"]
+>                 (Just [Name Nothing "d"])
+>                 DefaultReferenceMatch
+>                 DefaultReferentialAction DefaultReferentialAction
+>        ])
 
 
 <references specification> ::=

--- a/tools/Language/SQL/SimpleSQL/SQL2011Schema.lhs
+++ b/tools/Language/SQL/SimpleSQL/SQL2011Schema.lhs
@@ -334,7 +334,7 @@ todo: constraint characteristics
 >        [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
 >         [ColConstraintDef Nothing (ColPrimaryKeyConstraint False)]])
 
->     ,(TestStatement ansi2011
+>     ,(TestStatement ansi2011 { diAutoincrement = True }
 >       "create table t (a int primary key autoincrement);"
 >      $ CreateTable [Name Nothing "t"]
 >        [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing


### PR DESCRIPTION
SQlite doesn't require commas between `create table` constraints. This PR sketches out the implementation of this feature. The code works in practice, although someone more familiar with the codebase should make sure everything is in the right place.