### PR TITLE
Allow not specifying types for column defs

### DIFF
--- a/Language/SQL/SimpleSQL/Dialect.hs
+++ b/Language/SQL/SimpleSQL/Dialect.hs
@@ -98,6 +98,8 @@ data Dialect = Dialect
     ,diNonCommaSeparatedConstraints :: Bool
      -- | allow marking tables as "without rowid"
     ,diWithoutRowidTables :: Bool
+     -- | allow omitting types for columns
+    ,diOptionalColumnTypes :: Bool
     }
                deriving (Eq,Show,Read,Data,Typeable)
 
@@ -123,6 +125,7 @@ ansi2011 = Dialect {diKeywords = ansi2011ReservedKeywords
                    ,diAutoincrement = False
                    ,diNonCommaSeparatedConstraints = False
                    ,diWithoutRowidTables = False
+                   ,diOptionalColumnTypes = False
                    }
 
 -- | mysql dialect

--- a/Language/SQL/SimpleSQL/Parse.hs
+++ b/Language/SQL/SimpleSQL/Parse.hs
@@ -1737,9 +1737,12 @@ createIndex =
     <*> parens (commaSep1 (name "column name"))
 
 columnDef :: Parser ColumnDef
-columnDef = ColumnDef <$> name "column name" <*> typeName
-            <*> optional defaultClause
-            <*> option [] (some colConstraintDef)
+columnDef = do
+  optionalType <- askDialect diOptionalColumnTypes
+  ColumnDef <$> name "column name"
+    <*> (if optionalType then optional typeName else Just <$> typeName)
+    <*> optional defaultClause
+    <*> option [] (some colConstraintDef)
   where
     defaultClause = label "column default clause" $ choice [
         keyword_ "default" >>

--- a/Language/SQL/SimpleSQL/Pretty.hs
+++ b/Language/SQL/SimpleSQL/Pretty.hs
@@ -700,7 +700,7 @@ dropBehav Restrict = pretty "restrict"
 
 columnDef :: Dialect -> ColumnDef -> Doc a
 columnDef d (ColumnDef n t mdef cons) =
-      name n <+> typeName t
+      name n <+> maybe mempty typeName t
       <+> case mdef of
              Nothing -> mempty
              Just (DefaultClause def) ->

--- a/Language/SQL/SimpleSQL/Syntax.hs
+++ b/Language/SQL/SimpleSQL/Syntax.hs
@@ -553,7 +553,7 @@ data TableElement =
   | TableConstraintDef (Maybe [Name]) TableConstraint
     deriving (Eq,Show,Read,Data,Typeable)
 
-data ColumnDef = ColumnDef Name TypeName
+data ColumnDef = ColumnDef Name (Maybe TypeName)
        (Maybe DefaultClause)
        [ColConstraintDef]
        -- (Maybe CollateClause)

--- a/tests/Language/SQL/SimpleSQL/Oracle.hs
+++ b/tests/Language/SQL/SimpleSQL/Oracle.hs
@@ -25,7 +25,7 @@ oracleLobUnits = Group "oracleLobUnits"
       "create table t (a varchar2(55 BYTE));"
      $ CreateTable [Name Nothing "t"]
        [TableColumnDef $ ColumnDef (Name Nothing "a")
-        (PrecLengthTypeName [Name Nothing "varchar2"] 55 Nothing (Just PrecOctets))
+        (Just (PrecLengthTypeName [Name Nothing "varchar2"] 55 Nothing (Just PrecOctets)))
         Nothing []]
        False
     ]

--- a/tests/Language/SQL/SimpleSQL/SQL2011Schema.hs
+++ b/tests/Language/SQL/SimpleSQL/SQL2011Schema.hs
@@ -107,8 +107,8 @@ add schema element support:
 
     ,s "create table t (a int, b int);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []]
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []]
        False
 
 
@@ -327,35 +327,35 @@ todo: constraint characteristics
     ,s
       "create table t (a int not null);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing ColNotNullConstraint]]
        False
 
     ,s
       "create table t (a int constraint a_not_null not null);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef (Just [Name Nothing "a_not_null"]) ColNotNullConstraint]]
        False
 
     ,s
       "create table t (a int unique);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing ColUniqueConstraint]]
        False
 
     ,s
       "create table t (a int primary key);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing (ColPrimaryKeyConstraint False)]]
        False
 
     ,testStatement ansi2011{ diAutoincrement = True }
       "create table t (a int primary key autoincrement);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing (ColPrimaryKeyConstraint True)]]
        False
 
@@ -369,7 +369,7 @@ references t(a,b)
     ,s
       "create table t (a int references u);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          DefaultReferentialAction DefaultReferentialAction]]
@@ -378,7 +378,7 @@ references t(a,b)
     ,s
       "create table t (a int references u(a));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] (Just $ Name Nothing "a") DefaultReferenceMatch
          DefaultReferentialAction DefaultReferentialAction]]
@@ -387,7 +387,7 @@ references t(a,b)
     ,s
       "create table t (a int references u match full);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing MatchFull
          DefaultReferentialAction DefaultReferentialAction]]
@@ -396,7 +396,7 @@ references t(a,b)
     ,s
       "create table t (a int references u match partial);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing MatchPartial
          DefaultReferentialAction DefaultReferentialAction]]
@@ -405,7 +405,7 @@ references t(a,b)
     ,s
       "create table t (a int references u match simple);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing MatchSimple
          DefaultReferentialAction DefaultReferentialAction]]
@@ -414,7 +414,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on update cascade );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          RefCascade DefaultReferentialAction]]
@@ -423,7 +423,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on update set null );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          RefSetNull DefaultReferentialAction]]
@@ -432,7 +432,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on update set default );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          RefSetDefault DefaultReferentialAction]]
@@ -441,7 +441,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on update no action );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          RefNoAction DefaultReferentialAction]]
@@ -450,7 +450,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on delete cascade );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          DefaultReferentialAction RefCascade]]
@@ -460,7 +460,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on update cascade on delete restrict );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          RefCascade RefRestrict]]
@@ -469,7 +469,7 @@ references t(a,b)
     ,s
       "create table t (a int references u on delete restrict on update cascade );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing $ ColReferencesConstraint
          [Name Nothing "u"] Nothing DefaultReferenceMatch
          RefCascade RefRestrict]]
@@ -484,7 +484,7 @@ options
     ,s
       "create table t (a int check (a>5));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing
         [ColConstraintDef Nothing
          (ColCheckConstraint $ BinOp (Iden [Name Nothing "a"]) [Name Nothing ">"] (NumLit "5"))]]
        False
@@ -501,13 +501,13 @@ options
 
     ,s "create table t (a int generated always as identity);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"])
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"]))
         (Just $ IdentityColumnSpec GeneratedAlways []) []]
        False
 
     ,s "create table t (a int generated by default as identity);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"])
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"]))
         (Just $ IdentityColumnSpec GeneratedByDefault []) []]
        False
 
@@ -516,7 +516,7 @@ options
       "create table t (a int generated always as identity\n\
       \  ( start with 5 increment by 5 maxvalue 500 minvalue 5 cycle ));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"])
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"]))
         (Just $ IdentityColumnSpec GeneratedAlways
          [SGOStartWith 5
          ,SGOIncrementBy 5
@@ -529,7 +529,7 @@ options
       "create table t (a int generated always as identity\n\
       \  ( start with -4 no maxvalue no minvalue no cycle ));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"])
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"]))
         (Just $ IdentityColumnSpec GeneratedAlways
          [SGOStartWith (-4)
          ,SGONoMaxValue
@@ -560,8 +560,8 @@ generated always (valueexpr)
       "create table t (a int, \n\
       \                a2 int generated always as (a * 2));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "a2") (TypeName [Name Nothing "int"])
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "a2") (Just (TypeName [Name Nothing "int"]))
         (Just $ GenerationClause
          (BinOp (Iden [Name Nothing "a"]) [Name Nothing "*"] (NumLit "2"))) []]
        False
@@ -591,7 +591,7 @@ generated always (valueexpr)
 
     ,s "create table t (a int default 0);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"])
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"]))
         (Just $ DefaultClause $ NumLit "0") []]
        False
 
@@ -627,7 +627,7 @@ generated always (valueexpr)
     ,s
       "create table t (a int, unique (a));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef Nothing $ TableUniqueConstraint [Name Nothing "a"]
         ]
        False
@@ -635,7 +635,7 @@ generated always (valueexpr)
     ,s
       "create table t (a int, constraint a_unique unique (a));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef (Just [Name Nothing "a_unique"]) $
             TableUniqueConstraint [Name Nothing "a"]
         ]
@@ -646,8 +646,8 @@ generated always (valueexpr)
     ,s
       "create table t (a int, b int, unique (a,b));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef Nothing $
             TableUniqueConstraint [Name Nothing "a", Name Nothing "b"]
         ]
@@ -656,8 +656,8 @@ generated always (valueexpr)
     ,s
       "create table t (a int, b int, primary key (a,b));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef Nothing $
             TablePrimaryKeyConstraint [Name Nothing "a", Name Nothing "b"]
         ]
@@ -684,8 +684,8 @@ defintely skip
       "create table t (a int, b int,\n\
       \                foreign key (a,b) references u(c,d) match full on update cascade on delete restrict );"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef Nothing $
             TableReferencesConstraint
                 [Name Nothing "a", Name Nothing "b"]
@@ -699,7 +699,7 @@ defintely skip
       "create table t (a int,\n\
       \                constraint tfku1 foreign key (a) references u);"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef (Just [Name Nothing "tfku1"]) $
             TableReferencesConstraint
                 [Name Nothing "a"]
@@ -714,8 +714,8 @@ defintely skip
       \                foreign key (a) references u(c)\n\
       \                foreign key (b) references v(d));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef Nothing $
             TableReferencesConstraint
                 [Name Nothing "a"]
@@ -735,8 +735,15 @@ defintely skip
     ,testStatement ansi2011{ diWithoutRowidTables = True }
       "create table t (a int) without rowid;"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []]
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []]
        True
+    ,testStatement ansi2011{ diOptionalColumnTypes = True }
+      "create table t (a,b);"
+     $ CreateTable [Name Nothing "t"]
+       [TableColumnDef $ ColumnDef (Name Nothing "a") Nothing Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") Nothing Nothing []
+       ]
+       False
 
 
 {-
@@ -798,8 +805,8 @@ defintely skip
       "create table t (a int, b int, \n\
       \                check (a > b));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef Nothing $
             TableCheckConstraint
             (BinOp (Iden [Name Nothing "a"]) [Name Nothing ">"] (Iden [Name Nothing "b"]))
@@ -811,8 +818,8 @@ defintely skip
       "create table t (a int, b int, \n\
       \                constraint agtb check (a > b));"
      $ CreateTable [Name Nothing "t"]
-       [TableColumnDef $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
-       ,TableColumnDef $ ColumnDef (Name Nothing "b") (TypeName [Name Nothing "int"]) Nothing []
+       [TableColumnDef $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
+       ,TableColumnDef $ ColumnDef (Name Nothing "b") (Just (TypeName [Name Nothing "int"])) Nothing []
        ,TableConstraintDef (Just [Name Nothing "agtb"]) $
             TableCheckConstraint
             (BinOp (Iden [Name Nothing "a"]) [Name Nothing ">"] (Iden [Name Nothing "b"]))
@@ -854,7 +861,7 @@ alter table t add a int unique not null check (a>0)
     ,s
       "alter table t add column a int"
      $ AlterTable [Name Nothing "t"] $ AddColumnDef
-       $ ColumnDef (Name Nothing "a") (TypeName [Name Nothing "int"]) Nothing []
+       $ ColumnDef (Name Nothing "a") (Just (TypeName [Name Nothing "int"])) Nothing []
 
 {-
 todo: more add column


### PR DESCRIPTION
SQLite allows defining columns without a type next to them. This PR implements support for such syntax under a new dialect flag. This is a breaking change, as the type for `ColumnDef` changes.